### PR TITLE
Use TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-session-http ChangeLog
 
+## 3.3.0 -
+
+## Added
+- Add the ttl from bedrock.config.express.session to session data.
+- Add Usage section to the README to document new ttl feature.
+
 ## 3.2.1 - 2020-01-05
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Provides session information via a REST API
 
 - npm v3+
 
-
 ## Usage
   - GET on `routes.session` will refresh a session & return session data.
   - DELETE on `routes.session` will delete a session. 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Provides session information via a REST API
 ## Requirements
 
 - npm v3+
+
+
+## Usage
+  - GET on `routes.session` will refresh a session & return session data.
+  - DELETE on `routes.session` will delete a session. 
+
+  GET requests will return a JSON object containing session data.
+  This object should include the `session.ttl` and other data added by
+  libraries that listen for the `bedrock-session-http.session.get` event.
+  The ttl maybe used client side to determine when a session will expire.

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,16 +17,12 @@ const routes = bedrock.config['session-http'].routes;
 // add routes
 bedrock.events.on('bedrock-express.configure.routes', function(app) {
   app.get(routes.session, asyncHandler(async (req, res) => {
-    // the originalMaxAge is in ms and will result
-    // in an accurate expiration time even if the client's
-    // time is incorrect
-    const session = {};
-    const {originalMaxAge} = req.session.cookie || {};
-    if(originalMaxAge) {
-      session.originalMaxAge = originalMaxAge;
-    }
-    // return the ttl with each refresh
-    session.ttl = bedrock.config.express.session.ttl;
+    const {session: {ttl} = {}} = bedrock.config.express || {};
+    const session = {
+      // return the ttl with each refresh
+      // if the ttl is set
+      ttl
+    };
     // emit event with request and session and let listeners add session data
     await bedrock.events.emit(
       'bedrock-session-http.session.get', req, session);

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,11 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
     // the originalMaxAge is in ms and will result
     // in an accurate expiration time even if the client's
     // time is incorrect
+    const session = {};
     const {originalMaxAge} = req.session.cookie || {};
-    const session = {originalMaxAge};
+    if(originalMaxAge) {
+      session.originalMaxAge = originalMaxAge;
+    }
     // emit event with request and session and let listeners add session data
     await bedrock.events.emit(
       'bedrock-session-http.session.get', req, session);

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,8 @@ bedrock.events.on('bedrock-express.configure.routes', function(app) {
     if(originalMaxAge) {
       session.originalMaxAge = originalMaxAge;
     }
+    // return the ttl with each refresh
+    session.ttl = bedrock.config.express.session.ttl;
     // emit event with request and session and let listeners add session data
     await bedrock.events.emit(
       'bedrock-session-http.session.get', req, session);

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,12 @@ const routes = bedrock.config['session-http'].routes;
 // add routes
 bedrock.events.on('bedrock-express.configure.routes', function(app) {
   app.get(routes.session, asyncHandler(async (req, res) => {
+    // the originalMaxAge is in ms and will result
+    // in an accurate expiration time even if the client's
+    // time is incorrect
+    const {originalMaxAge} = req.session.cookie || {};
+    const session = {originalMaxAge};
     // emit event with request and session and let listeners add session data
-    const session = {};
     await bedrock.events.emit(
       'bedrock-session-http.session.get', req, session);
     res.status(200).json(session);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-session-http",
   "peerDependencies": {
     "bedrock": "1.0.6 - 3.x",
-    "bedrock-express": "2.1.0 - 3.x"
+    "bedrock-express": "2.1.0 - 4.x"
   },
   "devDependencies": {
     "eslint": "^7.21.0",


### PR DESCRIPTION
This adds `ttl` to the session on refresh if `bedrock.express.session.ttl` is set in your app's config files.

Please note there is a gist here: https://gist.github.com/aljones15/3defa74231551e5b9934d79609661ae1 with all of the various different permutations of express settings used to create this feature.